### PR TITLE
Do not patch properties with JsonIgnore attribute

### DIFF
--- a/src/Nancy.Patch.Tests/Mocks/TestModel.cs
+++ b/src/Nancy.Patch.Tests/Mocks/TestModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace Nancy.Patch.Tests.Mocks
 {
@@ -13,6 +14,12 @@ namespace Nancy.Patch.Tests.Mocks
         public string ReadOnlyName
         {
             get { return "Test"; }
+        }
+
+        [JsonIgnore]
+        public string ModelName
+        {
+            get { return "TestModelWithJsonIgnore"; }
         }
     }
 }

--- a/src/Nancy.Patch.Tests/Nancy.Patch.Tests.csproj
+++ b/src/Nancy.Patch.Tests/Nancy.Patch.Tests.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\Nancy.Testing.1.4.1\lib\net40\Nancy.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/src/Nancy.Patch.Tests/PatchExecutorTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExecutorTests.cs
@@ -179,5 +179,33 @@ namespace Nancy.Patch.Tests
             Assert.IsFalse(result);
             Assert.AreEqual("Could not find writable property: readonlyname", result.Message);
         }
+
+        [Test]
+        public void Patch_Ignore_Property_Decorated_With_JsonIgnoreAttribute_Return_True()
+        {
+            var from = new TestModel
+            {
+                Id = 1,
+                Description = "Original",
+            };
+            var to = new TestModel
+            {
+                Id = 2,
+                Description = "New",
+            };
+
+            var propertiesToMerge = new[]
+            {
+                "id",
+                "description",
+                "modelname"
+            };
+
+            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(from.Id, to.Id);
+            Assert.AreEqual(from.Description, to.Description);
+        }
     }
 }

--- a/src/Nancy.Patch.Tests/PatchExtensionTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExtensionTests.cs
@@ -86,6 +86,23 @@ namespace Nancy.Patch.Tests
 
             Assert.AreEqual(default(DateTime), result.CreatedAt);
         }
+
+        [Test]
+        public void ShouldIgnore_JsonIgnoreProperties()
+        {
+            var response = _browser.Patch("/", with =>
+            {
+                with.HttpRequest();
+                with.Body(
+                    "{\"id\": \"1\", \"description\":\"This is a description\", \"modelname\": \"Hello World\"}");
+                with.Header("Content-Type", "application/json");
+            });
+            var result = response.Body.DeserializeJson<TestModel>();
+
+            Assert.AreEqual(1, result.Id);
+            Assert.AreEqual("This is a description", result.Description);
+            Assert.AreEqual("TestModelWithJsonIgnore", result.ModelName);
+        }
         
         private class MockModule : NancyModule
         {

--- a/src/Nancy.Patch.Tests/packages.config
+++ b/src/Nancy.Patch.Tests/packages.config
@@ -3,5 +3,6 @@
   <package id="CsQuery" version="1.3.3" targetFramework="net45" />
   <package id="Nancy" version="1.4.3" targetFramework="net45" />
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Respects properties on models that are decorated with the JsonIgnore
attribute.